### PR TITLE
Upgrades OSSubprocess for Pharo 9

### DIFF
--- a/src/BaselineOfPythonBridge/BaselineOfPythonBridge.class.st
+++ b/src/BaselineOfPythonBridge/BaselineOfPythonBridge.class.st
@@ -12,7 +12,7 @@ BaselineOfPythonBridge >> baseline: spec [
 		do: [			
 			spec
 				baseline: 'OSSubprocess' 
-				with: [ spec repository: 'github://pharo-contributions/OSSubprocess:v1.0.0/repository' ].
+				with: [ spec repository: 'github://pharo-contributions/OSSubprocess:v1.3.0/repository' ].
 			spec
 				baseline: 'Python3Generator' 
 				with: [ spec repository: 'github://juliendelplanque/Python3Generator:v2.0.0/repository' ].


### PR DESCRIPTION
OSSubprocess:v1.3.0 is needed for loading it in Pharo 9